### PR TITLE
[ci skip] adding user @jhkennedy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @rsignell-usgs
+* @jhkennedy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,4 +45,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - jhkennedy
     - rsignell-usgs


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @jhkennedy as instructed in #1.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #1