### PR TITLE
update to v0.5.1, removed python-magic from core deps

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About earthaccess
-=================
+About earthaccess-feedstock
+===========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/earthdata-feedstock/blob/main/LICENSE.txt)
 
 Home: https://pypi.org/project/earthaccess/
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/earthdata-feedstock/blob/main/LICENSE.txt)
 
 Summary: Client Library for NASA Earthdata APIs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "earthaccess" %}
-{% set version = "0.5.0" %}
+{% set version = "0.5.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/e/{{ name }}/earthaccess-{{ version }}.tar.gz
-  sha256: a71bdc6f722c4131c8525cde8b147011776260b274419ca38174debfa7f461a2
+  sha256: 9b03d9dd301fef2873d7bb6cc9eb9d96fad953e460bac1de8bcc4bde5804196b
 
 build:
   number: 0
@@ -29,10 +29,7 @@ requirements:
     - s3fs >=2021.11, <2024
     - fsspec >=2022.1
     - tinynetrc >=1.3.1
-    - aiofiles >=0.8.0
-    - aiohttp >=3.8.0
     - multimethod >=1.8
-    - python-magic >=0.4
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@conda-forge-admin, please rerender